### PR TITLE
add use_existing_certificate option

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -51,12 +51,12 @@ resource "google_compute_target_https_proxy" "default" {
   count            = "${var.ssl ? 1 : 0}"
   name             = "${var.name}-https-proxy"
   url_map          = "${element(compact(concat(list(var.url_map), google_compute_url_map.default.*.self_link)), 0)}"
-  ssl_certificates = ["${google_compute_ssl_certificate.default.self_link}"]
+  ssl_certificates = [ "${element(compact(concat(list(var.certificate_link), google_compute_ssl_certificate.default.*.self_link)), 0)}" ]
 }
 
 resource "google_compute_ssl_certificate" "default" {
   project     = "${var.project}"
-  count       = "${var.ssl ? 1 : 0}"
+  count       = "${(var.ssl && !var.use_existing_certificate) ? 1 : 0}"
   name        = "${var.name}-certificate"
   private_key = "${var.private_key}"
   certificate = "${var.certificate}"

--- a/variables.tf
+++ b/variables.tf
@@ -60,16 +60,26 @@ variable url_map {
 }
 
 variable ssl {
-  description = "Set to `true` to enable SSL support, requires variables `private_key` and `certificate`."
+  description = "Set to `true` to enable SSL support, requires variables `private_key` and `certificate`, or `use_existing_certificate` and `certificate_link`."
   default     = false
 }
 
 variable private_key {
-  description = "Content of the private SSL key. Required if ssl is `true`."
+  description = "Content of the private SSL key. Required if `ssl` is `true` and `use_existing_certificate` is `false`."
   default     = ""
 }
 
 variable certificate {
-  description = "Content of the SSL certificate. Required if ssl is `true`."
+  description = "Content of the SSL certificate. Required if `ssl` is `true` and `use_existing_certificate` is `false`."
+  default     = ""
+}
+
+variable use_existing_certificate {
+  description = "Use a certificate that has already been created.  Requires `certificate_link`."
+  default     = true
+}
+
+variable certificate_link {
+  description = "self_link for an existing certificate to use in this load balancer."
   default     = ""
 }


### PR DESCRIPTION
This allows one to create a certificate separately to avoid having the key material appear in the tfstate file.